### PR TITLE
Case-sensitive changes.

### DIFF
--- a/src/Api/BoardGameGeek.php
+++ b/src/Api/BoardGameGeek.php
@@ -6,7 +6,7 @@ use JMichaelWard\BoardGameCollector\Cron\CronService;
 /**
  * Class BoardGameGeek
  *
- * @package JMichaelWard\BoardGameCollector\API
+ * @package JMichaelWard\BoardGameCollector\Api
  */
 class BoardGameGeek {
 	/**

--- a/src/Updater/GamesUpdater.php
+++ b/src/Updater/GamesUpdater.php
@@ -1,7 +1,7 @@
 <?php
 namespace JMichaelWard\BoardGameCollector\Updater;
 
-use JMichaelWard\BoardGameCollector\API\BoardGameGeek;
+use JMichaelWard\BoardGameCollector\Api\BoardGameGeek;
 use JMichaelWard\BoardGameCollector\Model\Games\BGGGameAdapter;
 use JMichaelWard\BoardGameCollector\Model\Games\GameData;
 use JMichaelWard\BoardGameCollector\Admin\Settings;


### PR DESCRIPTION
In order to run on case-sensitive systems (e.g. my Centos Lightsail instance), some case-sensitive changes need to be made.

Options screen still doesn't work, but at least the site doesn't HTTP500 constantly.